### PR TITLE
Fix Race.Elapsed

### DIFF
--- a/Spectrum.API/Game/Race.cs
+++ b/Spectrum.API/Game/Race.cs
@@ -9,6 +9,8 @@ namespace Spectrum.API.Game
         public static event EventHandler Started;
         public static event EventHandler Loaded;
 
+        private static TimeSpan _started = TimeSpan.Zero;
+
         static Race()
         {
             Events.ServerToClient.ModeFinished.Subscribe(data =>
@@ -25,17 +27,15 @@ namespace Spectrum.API.Game
             {
                 Loaded?.Invoke(default(object), System.EventArgs.Empty);
             });
+
+            Started += (sender, e) => {
+                _started = TimeSpan.FromSeconds(Time.timeSinceLevelLoad);
+            };
         }
 
         public static TimeSpan Elapsed()
         {
-            var playerIndex = G.Sys.PlayerManager_.Current_.inGameData_.LocalPlayerIndex_;
-            var mode = G.Sys.GameManager_.Mode_;
-
-            if(mode != null) 
-                return TimeSpan.FromSeconds(mode.GetDisplayTime(playerIndex));
-
-            return TimeSpan.Zero;
+            return TimeSpan.FromSeconds(Time.timeSinceLevelLoad) - _started;
         }
     }
 }


### PR DESCRIPTION
Fixes the time going negative when the 60 second countdown is up.

It's still not as precise as I want but by the looks of it this is as precise as the engine can get (So the third digit of the milliseconds is mostly for show - if it changes at all it's due to framerate dips)